### PR TITLE
Allow option multiselect

### DIFF
--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -250,6 +250,9 @@ class ChatBot extends Component {
       const option = currentStep.options.filter(o => o.value === data.value)[0];
       const trigger = this.getTriggeredStep(option.trigger, currentStep.value);
       delete currentStep.options;
+      if (currentStep.allowMultiselect) {
+        option.value = data.optionsSelected;
+      }
 
       currentStep = Object.assign(
         {},

--- a/lib/schemas/optionsSchema.js
+++ b/lib/schemas/optionsSchema.js
@@ -24,4 +24,9 @@ export default [
     types: ['object'],
     required: false,
   },
+  {
+    key: 'allowMultiselect',
+    types: ['boolean'],
+    required: false,
+  },
 ];

--- a/lib/steps/options/OptionsStep.js
+++ b/lib/steps/options/OptionsStep.js
@@ -10,48 +10,67 @@ class OptionsStep extends Component {
   /* istanbul ignore next */
   constructor(props) {
     super(props);
-
+    this.state = {
+      optionsSelected: []
+    };
     this.renderOption = this.renderOption.bind(this);
     this.onOptionClick = this.onOptionClick.bind(this);
   }
 
-  onOptionClick({ value }) {
-    this.props.triggerNextStep({ value });
+  onOptionClick({ value, allowMultiselect }) {
+    if (!allowMultiselect) {
+      return this.props.triggerNextStep({ value });
+    }
+    if (value === "proceed") {
+      return this.props.triggerNextStep({ value, optionsSelected: this.state.optionsSelected });
+    }
+    this.setState({
+      optionsSelected: [
+        ...this.state.optionsSelected,
+        value
+      ]
+    });
   }
 
-  renderOption(option) {
-    const { bubbleStyle } = this.props;
-    const { bubbleColor, fontColor } = this.props.step;
-    const { value, label } = option;
+  renderOption(allowMultiselect) {
+    return (option) => {
+      const { bubbleStyle } = this.props;
+      const { bubbleColor, fontColor } = this.props.step;
+      const { value, label } = option;
+      const optionElementStyles = [
+        bubbleStyle,
+        allowMultiselect && this.state.optionsSelected.includes(value) ? { borderWidth: 2 } : {}
+      ];
 
-    return (
-      <Option
-        key={value}
-        className="rsc-os-option"
-        onPress={() => this.onOptionClick({ value })}
-      >
-        <OptionElement
-          className="rsc-os-option-element"
-          style={bubbleStyle}
-          bubbleColor={bubbleColor}
+      return (
+        <Option
+          key={value}
+          className="rsc-os-option"
+          onPress={() => this.onOptionClick({ value, allowMultiselect })}
         >
-          <OptionText
-            class="rsc-os-option-text"
-            fontColor={fontColor}
+          <OptionElement
+            className="rsc-os-option-element"
+            style={optionElementStyles}
+            bubbleColor={bubbleColor}
           >
-            {label}
-          </OptionText>
-        </OptionElement>
-      </Option>
-    );
+            <OptionText
+              class="rsc-os-option-text"
+              fontColor={fontColor}
+            >
+              {label}
+            </OptionText>
+          </OptionElement>
+        </Option>
+      );
+    };
   }
 
   render() {
-    const { options } = this.props.step;
+    const { step: { options, allowMultiselect = false } } = this.props;
 
     return (
       <Options className="rsc-os">
-        {_.map(options, this.renderOption)}
+        {_.map(options, this.renderOption(allowMultiselect))}
       </Options>
     );
   }
@@ -60,7 +79,7 @@ class OptionsStep extends Component {
 OptionsStep.propTypes = {
   step: PropTypes.object.isRequired,
   triggerNextStep: PropTypes.func.isRequired,
-  bubbleStyle: PropTypes.object.isRequired,
+  bubbleStyle: PropTypes.object.isRequired
 };
 
 export default OptionsStep;

--- a/lib/steps/options/OptionsStep.js
+++ b/lib/steps/options/OptionsStep.js
@@ -36,9 +36,10 @@ class OptionsStep extends Component {
     return (option) => {
       const { bubbleStyle } = this.props;
       const { bubbleColor, fontColor } = this.props.step;
-      const { value, label } = option;
+      const { value, label, optionStyle } = option;
       const optionElementStyles = [
         bubbleStyle,
+        optionStyle,
         allowMultiselect && this.state.optionsSelected.includes(value) ? { borderWidth: 2 } : {}
       ];
 


### PR DESCRIPTION
This allow multiselect in steps where `options` is present. Selected options show up with a thicker border.

<img width="381" alt="Screenshot 2020-03-12 at 7 53 29 PM" src="https://user-images.githubusercontent.com/58222526/76531472-47785b80-649b-11ea-8d1c-5c0a896ef977.png">
